### PR TITLE
Locking down bridge and validator dependency versions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,15 +5,15 @@
   "requires": true,
   "dependencies": {
     "@adobe/reactor-bridge": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@adobe/reactor-bridge/-/reactor-bridge-9.1.0.tgz",
-      "integrity": "sha512-9KwQkgqMoc/ltUW1ok/U34sAfHnv0Z/WnnrLGySfjfbB3TjZ0C2vTDAJWNFJK1EzbJGfwm9qjTbRBYaDCzncFw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@adobe/reactor-bridge/-/reactor-bridge-9.1.1.tgz",
+      "integrity": "sha512-Ocl6ztwC3vGzXJ4kqahrzfQboWuArXBgCA8d3OpfYJxrgXuRs/Y0frQv3+02aU90l68Yqj9t90OsofN6mzb7Lw==",
       "requires": {
         "domready": "1.0.8",
         "layout-observer": "1.2.0",
         "once": "1.4.0",
-        "penpal": "2.5.1",
-        "promise-polyfill": "6.0.2"
+        "penpal": "2.7.2",
+        "promise-polyfill": "6.1.0"
       }
     },
     "@adobe/reactor-turbine-schemas": {
@@ -3992,9 +3992,9 @@
       }
     },
     "penpal": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/penpal/-/penpal-2.5.1.tgz",
-      "integrity": "sha1-vfaA5pqCO73x1cPPMpiMb4SE5BE="
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/penpal/-/penpal-2.7.2.tgz",
+      "integrity": "sha512-wiD5bREvHsPxOJTRXBLpt4h7QfLjNtWXL2me5MopsYXQ9tIOM8ehffDIgrNkMBJgtjLlLdrHw4LfLnij5q2R9Q=="
     },
     "pify": {
       "version": "2.3.0",
@@ -4068,9 +4068,9 @@
       "dev": true
     },
     "promise-polyfill": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.0.2.tgz",
-      "integrity": "sha1-2chtPcTcLfkBboiUbe/Wm0m0EWI="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.1.0.tgz",
+      "integrity": "sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc="
     },
     "proxy-addr": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "lint": "eslint 'src/**/*.js'"
   },
   "dependencies": {
-    "@adobe/reactor-bridge": "^9.1.0",
-    "@adobe/reactor-validator": "^1.0.0",
+    "@adobe/reactor-bridge": "9.1.1",
+    "@adobe/reactor-validator": "1.2.0",
     "ajv": "^5.2.3",
     "babel-core": "^6.18.2",
     "babel-loader": "^7.1.0",


### PR DESCRIPTION
@dompuiu I decided to lock down the bridge and validator dependency versions because it will help us  better coordinate timing with Lens. For example, when we have a change like our "promise from shared view methods" feature go out, we can make sure it gets released to the sandbox at the same time Lens goes to prod (or integration)? It also solved the issue of showing an update alert whenever there's a change to bridge or validator.