### PR TITLE
Npx support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Once Node.js is installed, run the sandbox by executing the following command fr
 npx @adobe/reactor-sandbox
 ```
 
-A server will be started at [http://localhost:3000](http://localhost:3000). If you navigate to that address in your browser, you will see the View Sandbox which allows you to test your views. You'll need to have previously created a view in your extension for it to show up in the sandbox. You can switch between views you would like to test using the controls toward the top of the page.
+A server will be started at [http://localhost:3000](http://localhost:3000) (HTTP) and [https://localhost:4000](https://localhost:4000) (HTTPS). If you navigate to one of addresses in your browser (you may have to accept a security certificate if you use the HTTPS server), you will see the View Sandbox which allows you to test your views. You'll need to have previously created a view in your extension for it to show up in the sandbox. You can switch between views you would like to test using the controls toward the top of the page.
 
 You may also click on the "Go to library sandbox" button at the top-right of the page to navigate to the library sandbox where you can test your library logic. See [Configuring the Sandbox](#configuring-the-sandbox) for how to configure the library sandbox for proper testing.
 

--- a/README.md
+++ b/README.md
@@ -6,52 +6,38 @@ This project provides a sandbox in which you can manually test your Launch exten
 
 For more information regarding Launch, please visit our [product website](http://www.adobe.com/enterprise/cloud-platform/launch.html).
 
-## Installing the Sandbox
+## Running the Sandbox
 
-To use this project you will need to have [Node.js](https://nodejs.org/en/) installed on your computer. After you [download and install Node.js](https://nodejs.org/en/download/) you will also have access to the [npm](https://www.npmjs.com/) package manager for JavaScript. Your npm version will need to be at least 3.0.0. You can check the installed version by running the following command from a command line:
-
+Before running the sandbox, you must first have [Node.js](https://nodejs.org/en/) installed on your computer. Your npm version (npm comes bundles with Node.js) will need to be at least 5.2.0. You can check the installed version by running the following command from a command line:
+                                                                                                      
 ```
 npm -v
 ```
 
-After you have installed Node.js on your machine, you will need to initialize your project. Create a folder for your project if you don't already have one. Inside the folder, run
+Once Node.js is installed, run the sandbox by executing the following command from the command line within your project's directory:
 
 ```
-npm init
+npx @adobe/reactor-sandbox
 ```
 
-You will need to provide the information requested on the screen. After this process is complete, you should have a file called `package.json` inside your folder.
-
-You will then need to install both @adobe/reactor-turbine and @adobe/reactor-sandbox and save them in your project's [`devDependencies`](https://docs.npmjs.com/files/package.json#devdependencies) by running
-```
-npm install @adobe/reactor-turbine @adobe/reactor-sandbox --save-dev
-```
-
-## Running the Sandbox
-
-To run the sandbox, run `node_modules/.bin/reactor-sandbox` from the command line within your project's directory. A server will be started at [http://localhost:3000](http://localhost:3000). If you navigate to that address in your browser, you will see the view sandbox which allows you to test your views. You'll need to have previously created a view in your extension for it to show up in the sandbox. You can switch between views you would like to test using the controls toward the top of the page.
+A server will be started at [http://localhost:3000](http://localhost:3000). If you navigate to that address in your browser, you will see the View Sandbox which allows you to test your views. You'll need to have previously created a view in your extension for it to show up in the sandbox. You can switch between views you would like to test using the controls toward the top of the page.
 
 You may also click on the "Go to library sandbox" button at the top-right of the page to navigate to the library sandbox where you can test your library logic. See [Configuring the Sandbox](#configuring-the-sandbox) for how to configure the library sandbox for proper testing.
 
-Rather than type the path to the `reactor-sandbox` script each time you would like the run the sandbox, you may wish to set up a [script alias](https://docs.npmjs.com/misc/scripts) by adding a `scripts` node to your `package.json` as follows:
-
-```javascript
-{
-  ...
-  "scripts": {
-    "sandbox": "reactor-sandbox"
-  }
-  ...
-}
-```
 
 Once this is in place, you may then run the sandbox by executing the command `npm run sandbox` from the command line.
 
 ## Configuring the Sandbox
 
-To configure the portion of the sandbox that allows you to test your library logic, you'll want to run `node_modules/.bin/reactor-sandbox init` (Mac/Linux) or `node_modules\.bin\reactor-sandbox init` (Windows) from the command line within your project's directory. This will generate a directory within your project named `.sandbox` that contains two files you may edit to configure the sandbox:
+To configure the Library Sandbox portion of the sandbox that allows you to test your library logic, execute the following command from the command line within your project's directory:
 
-  * `container.js` When Launch publishes a library, it consists of two parts: (1) a data structure that stores information about saved rules, data elements, and extension configuration and (2) an engine to operate on such a data structure. `container.js` is the data structure (not the engine) that you may modify to simulate saved rules, data elements, and extension configuration. This template will be used to produce a complete `container.js` (JavaScript from your extension will be added) which will be used in tandem with the Turbine engine inside the sandbox. If you need help understanding how to modify `container.js` for your needs, please let the Launch team know and we can help you out.
-  * `libSandbox.html` includes some simple HTML along with script tags to load a complete `container.js` and the Turbine engine. `libSandbox.html` can be modified to manually test whatever you would like. For example, if you're testing that your awesome new "focus" event feature works, you can add a text input to the web page to ensure your dummy rule fires when a form element receives focus.
+```
+npx @adobe/reactor-sandbox init
+```
+
+This will generate a directory within your project named `.sandbox` that contains two files you may edit to configure the sandbox:
+
+  * `container.js` When Launch publishes a library, it consists of two parts: (1) a data structure that stores information about saved rules, data elements, and extension configuration and (2) an engine to operate on such a data structure. `container.js` is the data structure (not the engine) that you may modify to simulate saved rules, data elements, and extension configuration. This template will be used to produce a complete `container.js` (JavaScript from your extension will be added) which will be used in tandem with the Turbine engine inside the sandbox. We have tried to provide inline comments on how to modify `container.js`, but if you need further help, please [let the Launch team know](https://developer.adobelaunch.com/guides/extensions/development-resources/) and we can help you out.
+  * `libSandbox.html` includes some simple HTML along with script tags to load a complete `container.js` and the Turbine engine. `libSandbox.html` can be modified to manually test whatever you would like. For example, if you'd like to test that your brand new "focus" event type is working as desired, you can add a text input to the `libSandbox.html` to ensure your dummy rule fires when a form element receives focus.
 
 You are welcome to commit `.sandbox` to your version control repository.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,72 @@
         "promise-polyfill": "6.1.0"
       }
     },
+    "@adobe/reactor-cookie": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@adobe/reactor-cookie/-/reactor-cookie-1.0.0.tgz",
+      "integrity": "sha512-MFHSHeuZxLkbe8A8WgXcuLdlOaVdbXzhzylUzVlJ3pOne0u0pmJUke5dXBIju7zCFk0rEJ0tjwR9eDjpcu8m1Q==",
+      "requires": {
+        "js-cookie": "2.1.4"
+      }
+    },
+    "@adobe/reactor-document": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@adobe/reactor-document/-/reactor-document-1.0.0.tgz",
+      "integrity": "sha512-HDANIJUoc0RjTyWz5oBCZ6zBFw68GXIauFM5KxAfWEJ+DRgnVeDz74TuZ4L0Co0dHlRFbbXF0XjpYmn5YWev9A=="
+    },
+    "@adobe/reactor-load-script": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@adobe/reactor-load-script/-/reactor-load-script-1.0.1.tgz",
+      "integrity": "sha512-2T0LzzKgAKNhx25mPGSureHT8cf6e690bAh1uLaBNf+qVigjGGIS4UoHJ7UQgE3cRPxKjibufYn/bnSFsUcZXg==",
+      "requires": {
+        "@adobe/reactor-promise": "1.0.0"
+      }
+    },
+    "@adobe/reactor-object-assign": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@adobe/reactor-object-assign/-/reactor-object-assign-1.0.0.tgz",
+      "integrity": "sha512-WI3uplIKeFqqGYyU0IRbXwq+7Nk40EF40s7UmDNL5hdVkiDhEtXmWmbuGPjapKQfe3BoxMlH+pk/rxTva/DaUw==",
+      "requires": {
+        "object-assign": "4.1.1"
+      }
+    },
+    "@adobe/reactor-promise": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@adobe/reactor-promise/-/reactor-promise-1.0.0.tgz",
+      "integrity": "sha512-SCK/JLUd7UhwXQvyYRB8B8zvpk2aW8aGf3Xx8dZVXiaHrULgcWfVB5IzpbTsdwbez2HmsVteT7L7xIS2PZW87A==",
+      "requires": {
+        "promise-polyfill": "6.0.2"
+      },
+      "dependencies": {
+        "promise-polyfill": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.0.2.tgz",
+          "integrity": "sha1-2chtPcTcLfkBboiUbe/Wm0m0EWI="
+        }
+      }
+    },
+    "@adobe/reactor-query-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@adobe/reactor-query-string/-/reactor-query-string-1.0.0.tgz",
+      "integrity": "sha512-Y6Cb9azVk+zIs9wEoOTMa01pzMqxFDPhRCfvZeW3YTAeR/b3kZOjD8loTpDt7bDj0vCZPRB2mhnVGOMCnsvBFQ==",
+      "requires": {
+        "querystring": "0.2.0"
+      }
+    },
+    "@adobe/reactor-turbine": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@adobe/reactor-turbine/-/reactor-turbine-25.1.0.tgz",
+      "integrity": "sha512-InBXLNFUq0teS2qPcN3SsxCMgYjs+tPZVb/e8gbaguiKIb9hP/J5Mpnm0UbEConPBQoMC/XDh84/TThrQiQUFw==",
+      "requires": {
+        "@adobe/reactor-cookie": "1.0.0",
+        "@adobe/reactor-document": "1.0.0",
+        "@adobe/reactor-load-script": "1.0.1",
+        "@adobe/reactor-object-assign": "1.0.0",
+        "@adobe/reactor-promise": "1.0.0",
+        "@adobe/reactor-query-string": "1.0.0",
+        "@adobe/reactor-window": "1.0.0"
+      }
+    },
     "@adobe/reactor-turbine-schemas": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@adobe/reactor-turbine-schemas/-/reactor-turbine-schemas-2.5.0.tgz",
@@ -37,6 +103,11 @@
           }
         }
       }
+    },
+    "@adobe/reactor-window": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@adobe/reactor-window/-/reactor-window-1.0.0.tgz",
+      "integrity": "sha512-n6B25+2/497ES7+SAtX4ikqJ67xpbGRP6Iqwe+J+ArO274MNh35K+h7ovXH+3yTgqtcJkujO8Pt+YmiuxxcPaQ=="
     },
     "accepts": {
       "version": "1.3.4",
@@ -3144,6 +3215,11 @@
       "requires": {
         "isarray": "1.0.0"
       }
+    },
+    "js-cookie": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.1.4.tgz",
+      "integrity": "sha1-2k7FA4ZvFJ0WTPJfV57zEBUCXY0="
     },
     "js-tokens": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint 'src/**/*.js'"
   },
   "dependencies": {
+    "@adobe/reactor-turbine": "25.1.0",
     "@adobe/reactor-bridge": "9.2.1",
     "@adobe/reactor-validator": "1.2.0",
     "ajv": "^5.2.3",
@@ -36,9 +37,6 @@
     "split.js": "^1.2.0",
     "webpack": "^3.8.1",
     "webpack-dev-middleware": "^1.6.1"
-  },
-  "peerDependencies": {
-    "@adobe/reactor-turbine": ">=22.0.0"
   },
   "bin": {
     "reactor-sandbox": "./src/tasks/index.js"

--- a/src/tasks/index.js
+++ b/src/tasks/index.js
@@ -13,10 +13,8 @@
  ****************************************************************************************/
 
 const execSync = require('child_process').execSync;
-const path = require('path');
 const chalk = require('chalk');
 const sandboxPkg = require('../../package.json');
-const turbinePkg = require(path.resolve('node_modules/@adobe/reactor-turbine/package.json'));
 const semverDiff = require('semver-diff');
 
 const getLatestVersion = packageName => {
@@ -26,16 +24,15 @@ const getLatestVersion = packageName => {
 };
 
 const sandboxOutdated = semverDiff(sandboxPkg.version, getLatestVersion('@adobe/reactor-sandbox'));
-const turbineOutdated = semverDiff(turbinePkg.version, getLatestVersion('@adobe/reactor-turbine'));
 
 const task = process.argv.slice(2)[0];
 
-if (sandboxOutdated || turbineOutdated) {
+if (sandboxOutdated) {
   console.log(
     chalk.red(
       'Your sandbox is out of date. To ensure you are testing against the ' +
         'latest code, please first update your sandbox by running ' +
-        `${chalk.cyan('npm i @adobe/reactor-sandbox@latest @adobe/reactor-turbine@latest')}.`
+        `${chalk.cyan('npm i @adobe/reactor-sandbox@latest')}.`
     )
   );
 }

--- a/src/tasks/webpack.viewSandbox.config.js
+++ b/src/tasks/webpack.viewSandbox.config.js
@@ -1,5 +1,5 @@
 
-
+const path = require('path');
 const files = require('./constants/files');
 const IgnorePlugin = require('webpack').IgnorePlugin;
 
@@ -38,6 +38,10 @@ module.exports = {
     new IgnorePlugin(/regenerator|nodent|js\-beautify/, /ajv/)
   ],
   resolveLoader: {
+    // Important so that the webpack loaders are found when sandbox is being used with npx
+    modules: [
+      path.resolve(__dirname, "../../node_modules")
+    ],
     moduleExtensions: ['-loader']
   }
 };


### PR DESCRIPTION
In order to allow extension developers to use the sandbox with npx and without a package.json, we can't really require that they have Turbine installed as a peer dependency. If I recall correctly, Turbine was marked as a peerDependency previously because we were also using Turbine from our internal extension-support-testrunner when we had our iframe-based tests, which is no longer the case.