### PR TITLE
DTM-12904 Added built-in action type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6720,8 +6720,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6739,13 +6738,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6758,18 +6755,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6872,8 +6866,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6883,7 +6876,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6896,20 +6888,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6926,7 +6915,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6999,8 +6987,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7010,7 +6997,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7086,8 +7072,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7117,7 +7102,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7135,7 +7119,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7174,13 +7157,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/src/tasks/helpers/editorRegistry.js
+++ b/src/tasks/helpers/editorRegistry.js
@@ -77,7 +77,14 @@ module.exports = (extensionDescriptorPaths, { request, ports }) => {
         }
       },
       conditions: {},
-      actions: {},
+      actions: {
+        'sandbox/logEventInfo.js': {
+          extensionDisplayName: 'Sandbox',
+          extensionName: 'sandbox',
+          displayName: 'Log Event Info',
+          libPath: 'logEventInfo.js'
+        }
+      },
       dataElements: {
         'sandbox/localStorage.js': {
           extensionDisplayName: 'Sandbox',

--- a/src/tasks/helpers/getContainer.js
+++ b/src/tasks/helpers/getContainer.js
@@ -184,6 +184,15 @@ const augmentSandboxEvents = function(extensionsOutput) {
             };
           }
         },
+        'sandbox/logEventInfo.js': {
+          displayName: 'Log Event Info',
+          name: 'log-event-info',
+          script: function(module) {
+            module.exports = function(settings, event) {
+              console.log("Event object received by action:", event);
+            };
+          }
+        },
         'sandbox/localStorage.js': {
           script: function(module) {
             module.exports = function(settings) {


### PR DESCRIPTION
This request comes from Conor Hackett on Slack: https://launch-developers.slack.com/archives/C7Z3LT3MF/p1549987429006100

This adds a built-in action type in the library sandbox (similar to how we have built-in event types) that logs the event.

@dompuiu I don't know how to test this in the sandbox rule editor. I ran `npm link` within the sandbox directory. I think ran `npm link @adobe/reactor-sandbox` from an extension directory. I then rean `npx @adobe/reactor-sandbox`. When I open the sandbox in the browser and try to navigate to the rule editor, I get `Cannot GET /editor.html`.