### PR TITLE
Remove warnings from console triggered by the action tabs.

### DIFF
--- a/src/app/viewSandbox/components/ControlTabs.jsx
+++ b/src/app/viewSandbox/components/ControlTabs.jsx
@@ -103,7 +103,12 @@ export default ({
   }, [resetId]);
 
   return (
-    <Tabs selectedKey={selectedTab} onSelectionChange={setSelectedTab} height="100%">
+    <Tabs
+      selectedKey={selectedTab}
+      onSelectionChange={setSelectedTab}
+      height="100%"
+      aria-label="Actions tabs"
+    >
       <div
         style={{
           borderBottom:
@@ -112,15 +117,15 @@ export default ({
       >
         <Flex justifyContent="center">
           <TabList position="relative" bottom="-0.1rem">
-            <Item key="init">
+            <Item key="init" textValue="Init">
               <BoxImport />
               <Text>Init</Text>
             </Item>
-            <Item key="settings">
+            <Item key="settings" textValue="Get settings">
               <BoxExport />
               <Text>Get Settings</Text>
             </Item>
-            <Item key="validate">
+            <Item key="validate" textValue="Validate">
               <AlertCheck />
               <Text>Validate</Text>
             </Item>


### PR DESCRIPTION
## Description

Remove warnings from the console. The warnings were triggered by the action tabs from the right part of the screen.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
